### PR TITLE
Make rate limiting message configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 tags:
-	find src -name '*.rs' | xargs ctags 
+	find src -name '*.rs' | xargs ctags
+
+build-linux:
+	cargo build --target x86_64-unknown-linux-musl --release
 
 .PHONY: tags

--- a/noteguard.toml
+++ b/noteguard.toml
@@ -4,7 +4,6 @@ pipeline = ["protected_events", "kinds", "content", "whitelist", "ratelimit"]
 [filters.ratelimit]
 posts_per_minute = 8
 whitelist = ["127.0.0.1"]
-message = "rate-limited: you are noting too much"
 
 [filters.content]
 filters = ["https://cdn.nostr.build/i/some-spammy-or-abusive-image-image.png"]

--- a/noteguard.toml
+++ b/noteguard.toml
@@ -4,6 +4,7 @@ pipeline = ["protected_events", "kinds", "content", "whitelist", "ratelimit"]
 [filters.ratelimit]
 posts_per_minute = 8
 whitelist = ["127.0.0.1"]
+message = "rate-limited: you are noting too much"
 
 [filters.content]
 filters = ["https://cdn.nostr.build/i/some-spammy-or-abusive-image-image.png"]

--- a/src/filters/ratelimit.rs
+++ b/src/filters/ratelimit.rs
@@ -12,6 +12,7 @@ pub struct Tokens {
 pub struct RateLimit {
     pub posts_per_minute: i32,
     pub whitelist: Option<Vec<String>>,
+    pub message: String,
 
     #[serde(skip)]
     pub sources: HashMap<String, Tokens>,
@@ -65,7 +66,7 @@ impl NoteFilter for RateLimit {
             return OutputMessage::new(
                 msg.event.id.clone(),
                 Action::Reject,
-                Some("rate-limited: you are noting too much".to_string()),
+                Some(self.message.clone()),
             );
         }
 

--- a/src/filters/ratelimit.rs
+++ b/src/filters/ratelimit.rs
@@ -12,7 +12,7 @@ pub struct Tokens {
 pub struct RateLimit {
     pub posts_per_minute: i32,
     pub whitelist: Option<Vec<String>>,
-    pub message: String,
+    pub message: Option<String>,
 
     #[serde(skip)]
     pub sources: HashMap<String, Tokens>,
@@ -66,7 +66,11 @@ impl NoteFilter for RateLimit {
             return OutputMessage::new(
                 msg.event.id.clone(),
                 Action::Reject,
-                Some(self.message.clone()),
+                Some(
+                    self.message
+                        .clone()
+                        .unwrap_or("rate-limited: you are noting too much".to_string()),
+                ),
             );
         }
 


### PR DESCRIPTION
Just a humble PR to make the rate-limiting message configurable.

Testing:

Edit `messages` under `[filters.ratelimit]` in `noteguard.toml` then

```
$ make build-linux
...
$ ./test/delayed | ./target/x86_64-unknown-linux-musl/release/noteguard
{"id":"68421a122cef086512b2c5bd29ca6285ced8bd8e302e347e3c5d90466c860a76","action":"accept"}
{"id":"68421a122cef086512b2c5bd29ca6285ced8bd8e302e347e3c5d90466c860a76","action":"accept"}
{"id":"68421a122cef086512b2c5bd29ca6285ced8bd8e302e347e3c5d90466c860a76","action":"accept"}
{"id":"68421a122cef086512b2c5bd29ca6285ced8bd8e302e347e3c5d90466c860a76","action":"accept"}
{"id":"68421a122cef086512b2c5bd29ca6285ced8bd8e302e347e3c5d90466c860a76","action":"accept"}
{"id":"68421a122cef086512b2c5bd29ca6285ced8bd8e302e347e3c5d90466c860a76","action":"accept"}
{"id":"68421a122cef086512b2c5bd29ca6285ced8bd8e302e347e3c5d90466c860a76","action":"accept"}
{"id":"68421a122cef086512b2c5bd29ca6285ced8bd8e302e347e3c5d90466c860a76","action":"accept"}
{"id":"68421a122cef086512b2c5bd29ca6285ced8bd8e302e347e3c5d90466c860a76","action":"reject","msg":"this is my custom message"}
{"id":"68421a122cef086512b2c5bd29ca6285ced8bd8e302e347e3c5d90466c860a76","action":"reject","msg":"this is my custom message"}
{"id":"68421a122cef086512b2c5bd29ca6285ced8bd8e302e347e3c5d90466c860a76","action":"reject","msg":"this is my custom message"}
{"id":"68421a122cef086512b2c5bd29ca6285ced8bd8e302e347e3c5d90466c860a76","action":"reject","msg":"this is my custom message"}
{"id":"68421a122cef086512b2c5bd29ca6285ced8bd8e302e347e3c5d90466c860a76","action":"reject","msg":"this is my custom message"}
...
```