### PR TITLE
Allow blacklisting CIDR ranges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "ipnetwork"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +440,7 @@ version = "0.1.0"
 dependencies = [
  "env_logger",
  "futures-util",
+ "ipnetwork",
  "log",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ forwarder = ["tokio-tungstenite", "tokio", "futures-util"]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.5"
+ipnetwork = "0.20.0"
 
 # forwarder deps
 tokio-tungstenite = { version = "0.23.1", optional = true, features = ["native-tls"] }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # noteguard
 
 A high performance note filter plugin system for [strfry]
@@ -107,6 +106,18 @@ The whitelist filter only allows notes to pass if it matches a particular pubkey
 
 Either criteria can match
 
+### Blacklist
+
+* name: `blacklist`
+
+The blacklist filter blocks notes that match any pubkey, ip, or CIDR range:
+
+- `pubkeys` *optional*: a list of hex public keys to block
+
+- `ips` *optional*: a list of IP addresses to block
+
+- `cidrs` *optional*: a list of CIDR ranges to block
+
 ### Kinds
 
 * name: `kinds`
@@ -154,7 +165,6 @@ be queued if the connection goes down (up to the `queue_size` buffer limit)
 - `relay` - the relay to forward notes to, eg: `ws://localhost:8080`
 
 - `queue_size` *optional* - size of the note queue, this is used to buffer notes if the connection goes down. Default is 1000.
-
 
 ## Testing
 

--- a/src/filters/blacklist.rs
+++ b/src/filters/blacklist.rs
@@ -1,15 +1,44 @@
 use crate::{Action, InputMessage, NoteFilter, OutputMessage};
+use ipnetwork::IpNetwork;
 use serde::Deserialize;
+use std::net::IpAddr;
+use std::str::FromStr;
 
 #[derive(Deserialize, Default)]
 pub struct Blacklist {
     pub pubkeys: Option<Vec<String>>,
     pub ips: Option<Vec<String>>,
+    pub cidrs: Option<Vec<String>>,
+}
+
+impl Blacklist {
+    fn is_ip_blocked(&self, ip: &str) -> bool {
+        if let Some(cidrs) = &self.cidrs {
+            for cidr in cidrs {
+                if let Ok(network) = IpNetwork::from_str(cidr) {
+                    if let Ok(addr) = IpAddr::from_str(ip) {
+                        if network.contains(addr) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
+        if let Some(ips) = &self.ips {
+            if ips.contains(&ip.to_string()) {
+                return true;
+            }
+        }
+
+        false
+    }
 }
 
 impl NoteFilter for Blacklist {
     fn filter_note(&mut self, msg: &InputMessage) -> OutputMessage {
         let reject_message = "blocked: pubkey/ip is blacklisted".to_string();
+
         if let Some(pubkeys) = &self.pubkeys {
             if pubkeys.contains(&msg.event.pubkey) {
                 return OutputMessage::new(
@@ -20,14 +49,8 @@ impl NoteFilter for Blacklist {
             }
         }
 
-        if let Some(ips) = &self.ips {
-            if ips.contains(&msg.source_info) {
-                return OutputMessage::new(
-                    msg.event.id.clone(),
-                    Action::Reject,
-                    Some(reject_message),
-                );
-            }
+        if self.is_ip_blocked(&msg.source_info) {
+            return OutputMessage::new(msg.event.id.clone(), Action::Reject, Some(reject_message));
         }
 
         OutputMessage::new(msg.event.id.clone(), Action::Accept, None)


### PR DESCRIPTION
Enables CIDR blocking in case a spammer is using multiple IP addresses in a specific range.

```
$ cargo test
   Compiling noteguard v0.1.0 (/home/user/git-repos/noteguard)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.67s
     Running unittests src/lib.rs (target/debug/deps/noteguard-5c03b805e5f0ad1b)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/main.rs (target/debug/deps/noteguard-9c26818f53f234ae)

running 9 tests
test tests::test_deserialize_input_message ... ok
test tests::test_blacklist_reject ... ok
test tests::test_blacklist_accept ... ok
test tests::test_blacklist_cidr ... ok
test tests::test_register_builtin_filters ... ok
test tests::test_load_config ... ok
test tests::test_whitelist_reject ... ok
test tests::test_run_filters_shadow_reject ... ok
test tests::test_run_filters_accept ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests noteguard

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```